### PR TITLE
Fix empty scope.nodes causing 400 Bad Request

### DIFF
--- a/src/shared/hooks/useGetChartData.ts
+++ b/src/shared/hooks/useGetChartData.ts
@@ -60,7 +60,7 @@ export const useGetChartData = async ({
       options: ['jsonwrap', 'flip', 'ms'],
       scope: {
         contexts: [contextId],
-        nodes,
+        nodes: nodes.length ? nodes : ['*'],
         dimensions,
         labels,
       },


### PR DESCRIPTION
## Summary

- When no nodes are selected in the Grafana query editor, the plugin was sending `scope.nodes: []` (empty array) to the Netdata Cloud API
- The API rejects empty arrays with 400 Bad Request
- This fix uses wildcard `['*']` when no nodes are selected, matching the UI tooltip behavior ("No selected Nodes means 'All Nodes' from the Room")

## Root Cause

In `src/shared/hooks/useGetChartData.ts`, the `nodes` parameter defaulted to an empty array and was passed directly to `scope.nodes` without handling the "no selection = all nodes" case.

## Changes

- `useGetChartData.ts`: Changed `nodes,` to `nodes: nodes.length ? nodes : ['*'],`

This is consistent with how `selectors.nodes` already uses `['*']` (line 69) and how `dimensions` and `labels` use `defaultSelectorValue` when empty.

## Testing

- [x] Lint passes (0 errors)
- [x] Build passes
- [ ] Manual testing in Grafana with Netdata datasource

Fixes netdata/netdata-cloud#1132