### PR TITLE
Fix Grafana plugin documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The installations below will use different tools like: curl, docker, jq, wget, u
 ### Directly through the Grafana UI
 
 Netdata is available in the Grafana Plugin catalog that can be accessed from the Grafana UI. 
-For details on how to: use the Plugin catalog, manage the plugins (install, update, uninstall), and other information, please check [this documentation](https://grafana.com/docs/grafana/latest/administration/plugin-management/#plugin-catalog).
+For details on how to: use the Plugin catalog, manage the plugins (install, update, uninstall), and other information, please check [this documentation](https://grafana.com/docs/grafana/latest/administration/plugin-management/).
 
 ### Docker
 


### PR DESCRIPTION
## Result

- removes a retired fragment from the Grafana plugin-management documentation link

## Validation

- the official replacement page is live and covers plugin installation, updates, and removal
- `git diff --check` passed
- independent review passed
