### PR TITLE
Move CI onto Node 24 actions and $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           ref: ${{ env.BRANCH }}
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v7
         with:
           node-version: '20.x'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache yarn cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup build environment
         id: build_environment
-        run: echo "::set-output name=BUILD_VERSION::$(jq -r .version package.json)"
+        run: echo "BUILD_VERSION=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
       - name: Package plugin
         run: |
@@ -67,7 +67,7 @@ jobs:
           zip "netdata-datasource-${{ steps.build_environment.outputs.BUILD_VERSION }}.zip" netdata-datasource -r
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: netdata-datasource-${{ steps.build_environment.outputs.BUILD_VERSION }}.zip
           path: ./netdata-datasource-${{ steps.build_environment.outputs.BUILD_VERSION }}.zip


### PR DESCRIPTION
## Problem

Every CI run is annotated with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`, `actions/checkout@v2`, `actions/setup-node@v2.1.2`, `actions/upload-artifact@v4`

The reality is worse than the annotation. Two of those actions declare **node12**, not node20 — the runner has been silently force-upgrading them across four runtimes:

| Action | Pinned | Declares | Bumped to | Declares |
|---|---|---|---|---|
| `actions/checkout` | v2 | `node12` | **v7** | `node24` |
| `actions/setup-node` | v2.1.2 | `node12` | **v7** | `node24` |
| `actions/cache` | v4 | `node20` | **v6** | `node24` |
| `actions/upload-artifact` | v4 | `node20` | **v7** | `node24` |

`upload-artifact` needed v6 or later — **v5 is still node20** and would not have cleared the warning.

## Also fixed: deprecated `::set-output`

Two occurrences remained in this workflow, deprecated in the same era as the Node 12 actions:

```yaml
- run: echo "::set-output name=dir::$(yarn cache dir)"
- run: echo "::set-output name=BUILD_VERSION::$(jq -r .version package.json)"
```

Both now write to `$GITHUB_OUTPUT`. The step ids and output keys are unchanged, so every `steps.*.outputs.*` reference still resolves.

The second one matters more than it looks: `BUILD_VERSION` names the artifact that `internal-deploy` hands to `Netdata Grafana Plugin Deploy` in `netdata/infra`. If `set-output` is ever switched off, that breaks the **deploy**, not just the build.

Worth noting `d3b875e` ("Replace set-output with ...>>$GITHUB_OUTPUT") already did this once; it appears to have been reintroduced by the `b441723` toolkit migration.

## Deliberately not changed

- **`node-version: '20.x'`** — that is the Node the plugin is *built* with, a separate decision from the runtime the actions themselves run on. Bumping it could change build output and belongs in its own change.
- **`matrix.node-version` in the node_modules cache key** — there is no matrix in this workflow, so it interpolates to empty. Pre-existing and harmless (it just makes the key `${{ runner.os }}--nodemodules-…`), left alone to keep this diff to one concern.

## Verification

This PR's own CI run exercises every bumped action on the real runner — checkout, setup-node, both caches, the build, and the artifact upload. `internal-deploy` is gated on `github.event_name == 'workflow_dispatch'`, so no deploy is triggered by this PR.

**What CI here does _not_ cover:** the cross-repo artifact handoff. `netdata/infra` downloads the artifact with `dawidd6/action-download-artifact@v6`, and only a `workflow_dispatch` run reaches it. Bumping `upload-artifact` v4 → v7 should be transparent to that consumer, but it is the one interaction worth confirming with a manual dispatch after merge.

Suggested post-merge check:

```bash
gh workflow run ci.yml --ref master -f BRANCH=master
```

then confirm the run in `netdata/infra` downloads the artifact and completes.
